### PR TITLE
Shorten footer subscribe link

### DIFF
--- a/themes/dadrian/layouts/partials/footer-nav.html
+++ b/themes/dadrian/layouts/partials/footer-nav.html
@@ -1,4 +1,4 @@
 <footer>
   <hr />
-  <small style="margin-left: 8px;"><a href="{{ "/" | absURL }}">David Adrian</a> | <a href="https://buttondown.email/dadrian">Subscribe via Email</a> | <span>&copy; David Adrian {{ .Date.Format "2006" | default "2026" }} <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a></small>
+  <small style="margin-left: 8px;"><a href="{{ "/" | absURL }}">David Adrian</a> | <a href="https://buttondown.email/dadrian">Subscribe</a> | <span>&copy; David Adrian {{ .Date.Format "2006" | default "2026" }} <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a></small>
 </footer>


### PR DESCRIPTION
### Motivation
- Shorten the footer newsletter link text from `Subscribe via Email` to `Subscribe` to make the footer more concise while preserving the existing newsletter URL.

### Description
- Updated the partial `themes/dadrian/layouts/partials/footer-nav.html` by replacing the link text with `Subscribe` while keeping the `https://buttondown.email/dadrian` href unchanged.

### Testing
- Attempted to build with `hugo --minify` but it could not be run in this environment because Hugo is not installed (`/bin/bash: line 1: hugo: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4aaccc90832dbe99daa1430e219e)