### PR TITLE
Remove Netlify references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 dadrian.io
 ==========
-
-`HUGO_VERSION` is set in Netlify. You always forget this.

--- a/static/_redirects
+++ b/static/_redirects
@@ -4,7 +4,3 @@ https://blog.dadrian.io/* https://dadrian.io/blog/:splat 302!
 https://blog.davidadrian.org/* https://dadrian.io/blog/:splat 302!
 https://dadrian.dev/* https://dadrian.io/:splat 301!
 https://www.dadrian.dev/* https://dadrian.io/:splat 301!
-
-# Redirect primary netlify subdomain to primary alias
-https://dadrian-io.netlify.com/* https://dadrian.io/:splat 301!
-


### PR DESCRIPTION
### Motivation
- Remove Netlify-specific references and redirects from the repository to make the project provider-agnostic.
- Avoid advertising or relying on a Netlify subdomain in the site's static redirect rules.

### Description
- Deleted the README note that mentioned Netlify and `HUGO_VERSION` from `README.md`.
- Removed the Netlify subdomain redirect entry from `static/_redirects` so only active domain aliases remain.

### Testing
- Ran `rg -n "Netlify|netlify" . -g '!node_modules' -g '!vendor' -g '!dist' -g '!build'` and no matches were found.
- Ran `git diff --check` and there were no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06941798f4832daf93c9129f69a2d6)